### PR TITLE
PR #4: Calendar Adjustments + Clickable Events That Display Information

### DIFF
--- a/rebel-extension/src/SidePanelApp.css
+++ b/rebel-extension/src/SidePanelApp.css
@@ -1,11 +1,25 @@
 /* This file contains styles specific to App.jsx. */
 #sidepanel-root {
   max-width: 2000px;
-  min-width: 450px;
+  min-width: 350px;
+  width: 100%;
   background-color: var(--app-background, #8b0000);;
   margin: 0 auto;
-  padding: 2rem;
+  padding: 0.5rem;
   text-align: center;
+  justify-content: center;
+  
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  /*  ai (ChatGPT-4o, 2) */
+  overflow-x: hidden; /* 🔒 no horizontal scroll */
+  box-sizing: border-box;
 }
 
 .accordion-button {

--- a/rebel-extension/src/components/CalendarView.jsx
+++ b/rebel-extension/src/components/CalendarView.jsx
@@ -1,6 +1,9 @@
 import { useEffect, useState, useRef } from "react";
 import "../App.css";
 import "./css/CalendarView.css";
+import calendarEvents from "./calendarEvents.js";
+import Modal from 'react-bootstrap/Modal';
+import Button from 'react-bootstrap/Button';
 
 //date-fns localizer for big-calendar
 import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
@@ -48,6 +51,58 @@ function CalendarMenu() {
 	const maxLimit = setMinutes(setHours(new Date(), 23), 59);
 
 	const [events, setEvents] = useState([]);
+	const [select, setSelect] = useState();
+	const [show, setShow] = useState(false);
+	const [modalTitle, setmodalTitle] = useState('Modal Title');
+	const [modalBody, setmodalBody] = useState('Modal Body');
+	
+	const handleClose = () => setShow(false);
+  	const handleShow = () => setShow(true);
+	
+	const handleSelect = (event) => {
+		setSelect(event);
+		setShow(true);
+		setmodalTitle(event.title);
+		
+		//IDEA:  USE A STATE OR THE EVENT TO DIRECT CONTROL FLOW TO 2 DIFFERENT TEMPLATES FOR FORMATTING
+		//	 EVENT (1) 	--> TITLE, STARTS, ENDS, DESCRIPTION, LOCATION
+		//				*NOTE: EVENT MAY HAVE A COMBINATION OF: DESCRIPTION AND LOCATION, ONE OR THE OTHER IS MISSING, BOTH ARE MISSING
+		//	 ASSIGNMENT (0) --> TITLE, DUE, COURSE
+		
+		if(event.id === 1){
+			const eventStart = "Started at: \t\t" + ((event.start).toString()).slice(0,15) + ", " + (event.start).toLocaleTimeString('en-US', {
+			hour: 'numeric',
+			minute: 'numeric',
+			hour12: 'true'
+			}) + '\n';
+			const eventEnd = "Ends at: \t\t" + ((event.end).toString()).slice(0,15) + ", " + (event.end).toLocaleTimeString('en-US', {
+			hour: 'numeric',
+			minute: 'numeric',
+			hour12: 'true'
+			}) + '\n';
+			const eventDate = ((event.start).getTime() === (event.end).getTime()) ? ("Date: \t\t\t" + ((event.start).toString()).slice(0,15) + ", " + (event.start).toLocaleTimeString('en-US', {
+			hour: 'numeric',
+			minute: 'numeric',
+			hour12: 'true'
+			}) + '\n') : ( undefined ) ;
+			const eventLocation = event.location === undefined ? "" : ("Location: \t\t" + (event.location).toString() + '\n');
+			const eventDesc = event.description === undefined ? "" :  ("Description: \t" + (event.description).toString());
+		
+			if(eventDate === undefined){
+				setmodalBody(eventStart + eventEnd + eventLocation + eventDesc);}
+			else{
+				setmodalBody(eventDate + eventLocation + eventDesc);}
+			
+		} else {
+			const eventDue = "Due at: \t\t" + ((event.end).toString()).slice(0,15) + ", " + (event.end).toLocaleTimeString('en-US', {
+			hour: 'numeric',
+			minute: 'numeric',
+			hour12: 'true'
+			}) + '\n';
+			const eventCourse = "Course: \t" + (event.course).toString();
+			setmodalBody(eventDue + eventCourse);
+		}
+	};
 
 	useEffect(() => {
 		const fetchEvents = async () => {
@@ -71,7 +126,8 @@ function CalendarMenu() {
   	<div >
     	  <Calendar
       	  localizer={localizer}
-      	  events={events}	
+      	  events={calendarEvents}
+      	  //events={events}	
           defaultView= 'day'		
           views= {['day', 'week']}	
       	  startAccessor="start"
@@ -80,8 +136,21 @@ function CalendarMenu() {
       	  min= {minLimit}
       	  max= {maxLimit}
       	  defaultDate = {new Date()}
-      	  style={{ height: 600 }}
+      	  selected = {select}
+      	  onSelectEvent = {handleSelect}
+      	  style={{ height: 700 }}
     	  />
+    	  <Modal show={show} onHide={handleClose}>
+        	<Modal.Header closeButton closeVariant="black">
+          		<Modal.Title>{modalTitle}</Modal.Title>
+        	</Modal.Header>
+        	<Modal.Body style={{ whiteSpace: 'pre' }} >{modalBody}</Modal.Body>
+        	<Modal.Footer>
+          	<Button variant="secondary" onClick={handleClose} style={{color:"#ffffff"}}>
+            		Close
+          	</Button>
+        	</Modal.Footer>
+      	  </Modal>
   	</div>
 	);  
 }

--- a/rebel-extension/src/components/CalendarView.jsx
+++ b/rebel-extension/src/components/CalendarView.jsx
@@ -20,17 +20,19 @@ import { setMinutes } from "date-fns";
  *			     (from locale or machine) and displays a calendar based on the day.
  * Uses: react-big-calendar to display and format the calendar
  *	 date-fns for reading and parsing the date from the locale.
+ *       react-bootstrap to display events via the "Modal" component.
  *
  * Features:
- * - Selecting "Daily Reminders" places a Calendar object into the extension,
- *   and renders a Day-Only view of the calendar. Should display assignments and events from backend (TBD).
+ * - Selecting "Day" or "Week" displays a range of dates based on the current date (or locale).
+ *   Renders Day-view or Week-view. Should display assignments and events from backend (TBD).
  *
  * Components:
- * - react-big-calendar.css for styling. (Modified to fit the extension's color scheme and size)
+ * - CalendarView.css for styling. (Modified to fit the extension's color scheme and size)
+ * - react-boostrap / Modal for displaying events in a pop-up window. (Formatted manually but styled via CalendarView.css
  *
  * Authored by: Jeremy Besitula
  *
- * Put into component DailyCalendar.jsx by Jeremy Besitula
+ * Put into component CalendarView.jsx by Jeremy Besitula
  * @returns {JSX.Element} The react-big-calendar component UI.
  */
  
@@ -70,23 +72,23 @@ function CalendarMenu() {
 		//	 ASSIGNMENT (0) --> TITLE, DUE, COURSE
 		
 		if(event.id === 1){
-			const eventStart = "Started at: \t\t" + ((event.start).toString()).slice(0,15) + ", " + (event.start).toLocaleTimeString('en-US', {
+			const eventStart = "Started at:\t\t" + ((event.start).toString()).slice(0,15) + ", " + (event.start).toLocaleTimeString('en-US', {
 			hour: 'numeric',
 			minute: 'numeric',
 			hour12: 'true'
 			}) + '\n';
-			const eventEnd = "Ends at: \t\t" + ((event.end).toString()).slice(0,15) + ", " + (event.end).toLocaleTimeString('en-US', {
+			const eventEnd = "Ends at:\t\t" + ((event.end).toString()).slice(0,15) + ", " + (event.end).toLocaleTimeString('en-US', {
 			hour: 'numeric',
 			minute: 'numeric',
 			hour12: 'true'
 			}) + '\n';
-			const eventDate = ((event.start).getTime() === (event.end).getTime()) ? ("Date: \t\t\t" + ((event.start).toString()).slice(0,15) + ", " + (event.start).toLocaleTimeString('en-US', {
+			const eventDate = ((event.start).getTime() === (event.end).getTime()) ? ("Date:\t\t\t" + ((event.start).toString()).slice(0,15) + ", " + (event.start).toLocaleTimeString('en-US', {
 			hour: 'numeric',
 			minute: 'numeric',
 			hour12: 'true'
 			}) + '\n') : ( undefined ) ;
-			const eventLocation = event.location === undefined ? "" : ("Location: \t\t" + (event.location).toString() + '\n');
-			const eventDesc = event.description === undefined ? "" :  ("Description: \t" + (event.description).toString());
+			const eventLocation = event.location === undefined ? "" : ("Location:\t\t" + (event.location).toString() + '\n');
+			const eventDesc = event.description === undefined ? "" :  ("Description:\t" + (event.description).toString());
 		
 			if(eventDate === undefined){
 				setmodalBody(eventStart + eventEnd + eventLocation + eventDesc);}
@@ -94,12 +96,12 @@ function CalendarMenu() {
 				setmodalBody(eventDate + eventLocation + eventDesc);}
 			
 		} else {
-			const eventDue = "Due at: \t\t" + ((event.end).toString()).slice(0,15) + ", " + (event.end).toLocaleTimeString('en-US', {
+			const eventDue = "Due at:\t\t" + ((event.end).toString()).slice(0,15) + ", " + (event.end).toLocaleTimeString('en-US', {
 			hour: 'numeric',
 			minute: 'numeric',
 			hour12: 'true'
 			}) + '\n';
-			const eventCourse = "Course: \t" + (event.course).toString();
+			const eventCourse = "Course:\t\t" + (event.course).toString();
 			setmodalBody(eventDue + eventCourse);
 		}
 	};

--- a/rebel-extension/src/components/SidePanelButton.jsx
+++ b/rebel-extension/src/components/SidePanelButton.jsx
@@ -22,7 +22,7 @@ function SidePanelButton() {
   return (
     <div>
       <button onClick={handleOpenSidePanel}>
-        Calendar View --&gt;
+        Calendar View
       </button>
     </div>
   );

--- a/rebel-extension/src/components/calendarEvents.js
+++ b/rebel-extension/src/components/calendarEvents.js
@@ -1,27 +1,38 @@
 export default [
   {
-    'title': '3 Day Event very long title',
-    'start': new Date(2025, 2, 24),
-    'end': new Date(2025, 2, 27)
+    'title': 'UNLV Food Festival',
+    'start': new Date(2025, 3, 1),
+    'end': new Date(2025, 3, 3),
+    'location': 'UNLV - Pida Plaza',
+    'description': 'Pida Plaza Potluck Palooza',
+    'id': 1
   },
   {
-    'title': 'One day event',
-    'start': new Date(2025, 2, 26),
-    'end': new Date(2025, 2, 26)
+    'title': 'FAFSA Due Date',
+    'start': new Date(2025, 3, 2),
+    'end': new Date(2025, 3, 2),
+    'id': 1
   },
   {
-    'title': 'Today Event',
-    'start': new Date(2025, 2, 24),
-    'end': new Date(2025, 2, 24)
+    'title': 'CS302 - OH',
+    'start': new Date(2025, 3, 3),
+    'end': new Date(2025, 3, 3),
+    'location': 'TBE-B 308',
+    'description': 'Office Hours with Jimi',
+    'id': 1
   },
   {
-    'title': 'Later Event',
-    'start': new Date(2025, 2, 24, 15, 0, 0),
-    'end': new Date(2025, 2, 24, 17, 0, 0)
+    'title': 'Art Show',
+    'start': new Date(2025, 3, 4, 15, 0, 0),
+    'end': new Date(2025, 3, 4, 17, 0, 0),
+    'location': "Greenspun Hall",
+    'id': 1
   },
   {
-    'title': 'Also Later Event',
-    'start': new Date(2025, 2, 24, 15, 0, 0),
-    'end': new Date(2025, 2, 24, 17, 0, 0)
-  }
+    'title': 'Phase 4',
+    'start': new Date(2025, 3, 5, 17, 0, 0),
+    'end': new Date(2025, 3, 5, 17, 0, 0),
+    'course': 'CS460',
+    'id': 0
+  },
 ];

--- a/rebel-extension/src/components/css/CalendarView.css
+++ b/rebel-extension/src/components/css/CalendarView.css
@@ -23,13 +23,27 @@ button.rbc-input::-moz-focus-inner {
   padding: 0;
 }
 
+.modal-header{
+  background-color: crimson;
+}
+
+.modal-content{
+  background-color: #808080;
+  color: white;
+}
+
+.btn-secondary{
+  background-color:#000000;
+}
+
 .rbc-calendar {
   background-color: #808080;
   border-radius: 8px;
   -webkit-box-sizing: border-box;
           box-sizing: border-box;
   height: 100%;
-  width: 600px;	/* I CHANGED TO FIX THE OFFSET ISSUE ~Jeremy */
+  min-width: 350px;	/* I CHANGED TO FIX THE OFFSET ISSUE ~Jeremy */
+  width: auto;
   display: -webkit-box;
   display: -ms-flexbox;
   display: flex;

--- a/rebel-extension/src/tests/Calendar.test.jsx
+++ b/rebel-extension/src/tests/Calendar.test.jsx
@@ -1,9 +1,10 @@
-import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import CalendarView from '../components/CalendarView';
-import Modal from 'react-bootstrap/Modal';
-import Button from 'react-bootstrap/Button';
-import calendarEvents from "../components/calendarEvents.js";
 import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 global.chrome = {
   runtime: {
@@ -23,54 +24,10 @@ global.chrome = {
     },
   },
 };
-
-
-jest.mock("../components/calendarEvents.js", () => [
-  {
-    id: 1,
-    title: "Test Event",
-    start: new Date(),
-    end: new Date(),
-    description: "This is a test event description.",
-    location: "Test Location",
-  },
-]);
-
 // Mocking the react-big-calendar and date-fns libraries
 jest.mock('react-big-calendar', () => ({
-  //Calendar: () => <div>mockCalendarView</div>,
-
-  
-  Calendar: ({ onSelectEvent }) => {
-    // Trigger the onSelectEvent function when the event is "clicked"
-    return (
-      <div onClick={() => onSelectEvent({ title: 'Test Event', start: new Date(), end: new Date(), description: 'This is a test event description.', location: 'Test Location', id: 1 })}>
-        Calendar Component
-      </div>
-    );
-  },
-  
-  
+  Calendar: () => <div>Calendar Component</div>,
   dateFnsLocalizer: jest.fn(() => ({})), // Mock dateFnsLocalizer
-}));
-
-// Mock the handleSelect function globally above the tests
-const handleSelectMock = jest.fn((event) => {
-  // Mock the behavior of handleSelect that sets modal state
-  setSelect(event);
-  setShow(true);
-  setmodalTitle(event.title);
-  setmodalBody(
-    `Started at: ${event.start.toString().slice(0, 15)}, ${event.start.toLocaleTimeString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true })} 
-    Ends at: ${event.end.toString().slice(0, 15)}, ${event.end.toLocaleTimeString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true })}
-    Location: ${event.location}
-    Description: ${event.description}`
-  );
-});
-
-jest.mock("react-bootstrap/Modal", () => ({
-  ...jest.requireActual("react-bootstrap/Modal"),
-  show: jest.fn(),
 }));
 
 // Mock date-fns and any specifically named imported like setHours/setMinutes
@@ -126,45 +83,5 @@ describe('Calendar View Component', () => {
 
     // Check that the Calendar component receives and uses the events prop
     expect(screen.getByText('Calendar Component')).toBeInTheDocument();
-  });
-  
-  it('testing the modal if it opens', async () => {
-    /*
-    // Create mock event data
-    const mockEvent = {
-      id: 1,
-      title: "Test Event",
-      start: new Date(),
-      end: new Date(),
-      description: "Test event description",
-      location: "Test Location",
-    };
-    */
-    
-    /* 
-    await act(async () => {
-    render(<CalendarView />);
-    });
-    */
-    
-    // Render the CalendarView component and pass mockEvent
-    
-    await act(async () => {
-      render(<CalendarView onSelectEvent={handleSelectMock}/* events={mockEvent} onSelectEvent={handleSelectMock}*/ />);
-    });
-    
-    fireEvent.click(screen.getByText('Test Event'));
-    
-    await waitFor(() => screen.getByText('Event Details'));
-    
-    // Check if the mock handleSelect was called
-    //expect(handleSelectMock).toHaveBeenCalledWith(mockEvent);
-    
-    const modal = screen.getByRole('dialog');
-    expect(modal).toBeInTheDocument();
-
-    // Check if the modal displays the event details
-    expect(screen.getByText("Test event description")).toBeInTheDocument();
-    expect(screen.getByText("Test Location")).toBeInTheDocument();
   });
 });

--- a/rebel-extension/src/tests/Calendar2.test.jsx
+++ b/rebel-extension/src/tests/Calendar2.test.jsx
@@ -1,0 +1,158 @@
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import CalendarView from '../components/CalendarView';
+import calendarEvents from "../components/calendarEvents.js";
+import { Calendar, dateFnsLocalizer } from 'react-big-calendar';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+jest.mock('react-bootstrap/Modal', () => ({
+  ...jest.requireActual('react-bootstrap/Modal'),
+  show: jest.fn(),
+  hide: jest.fn(),
+}));
+
+global.chrome = {
+  runtime: {
+    onMessage: {
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+    },
+  },
+  storage: {
+    local: {
+      get: jest.fn((key, callback) => {
+        callback({ title: "Test_Assignment",
+		   start: new Date(),
+	           end: new Date(),
+		   description: "Description 1" });
+      }),
+    },
+  },
+};
+
+// Mock date-fns and any specifically named imported like setHours/setMinutes
+jest.mock('date-fns', () => ({
+  __esModule: true,
+  ...jest.requireActual('date-fns'), // Mock while still preserving original functionality
+  setHours: jest.fn(),  // Named import setHours
+  setMinutes: jest.fn(),  // Named import setMinutes
+  format: jest.fn(),
+  parse: jest.fn(),
+  startOfWeek: jest.fn(),
+  getDay: jest.fn(),
+  locale: { enUS: {} },
+}));
+
+const mockcalendarEvents = [
+  {
+    id: 1,
+    title: "Test Event 1",
+    start: new Date(),
+    end: new Date(),
+    description: "This is a test event description.",
+    location: "Test Location",
+  },
+];
+
+// Mock the handleSelect function globally above the tests
+const handleSelectMock = jest.fn((event) => {
+  // Mock the behavior of handleSelect that sets modal state
+  setSelect(event);
+  setShow(true);
+  setmodalTitle(event.title);
+  setmodalBody(
+    `Started at: ${event.start.toString().slice(0, 15)}, ${event.start.toLocaleTimeString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true })} 
+    Ends at: ${event.end.toString().slice(0, 15)}, ${event.end.toLocaleTimeString('en-US', { hour: 'numeric', minute: 'numeric', hour12: true })}
+    Location: ${event.location}
+    Description: ${event.description}`
+  );
+});
+
+
+jest.mock('react-big-calendar', () => ({
+  ...jest.requireActual('react-big-calendar'),
+  Calendar: ({ onSelectEvent }) => {
+    // Trigger the onSelectEvent function when the event is "clicked"
+    return (
+      <div onClick={() => onSelectEvent({ title: 'Test Event 1', start: new Date(), end: new Date(), description: 'This is a test event description.', location: 'Test Location', id: 1 })}>
+        Mocked Calendar
+      </div>
+    );
+  },
+  dateFnsLocalizer: jest.fn(() => ({}))
+}));
+
+
+describe('CalendarView Component', () => {
+  it('opens modal and displays correct content when event is clicked', async () => {
+    
+    await act(async () => {
+    render(<CalendarView />);
+    });
+    
+    fireEvent.click(screen.getByText('Mocked Calendar'));
+
+    // Find and click the first event in the calendar
+    const eventElement = screen.getByText('Test Event 1');
+    fireEvent.click(eventElement);
+
+    // Check that modal opens and displays the correct information
+    await waitFor(() => {
+      expect(screen.getByText('Test Event 1')).toBeInTheDocument();
+    });
+  });
+
+  it('modal content is properly formatted and displays information accoridngly', async () => {
+    await act(async () => {
+    render(<CalendarView />);
+    });
+    
+    fireEvent.click(screen.getByText('Mocked Calendar'));
+    
+    const mockEvent = (mockcalendarEvents[0]);
+
+    // Find and click the first event in the calendar
+    const eventElement = screen.getByText(mockEvent.title);
+    fireEvent.click(eventElement);
+    
+    // Check that modal opens and displays the correct information
+    await waitFor(() => {
+      expect(screen.getByText('Test Event 1')).toBeInTheDocument();
+    });
+    
+    // Check for location and description details
+    const eventLocation = mockEvent.location;
+    const eventDescription = mockEvent.description;
+    expect(eventLocation).toEqual(expect.stringContaining("Location"));
+    expect(eventDescription).toEqual(expect.stringContaining("description"));
+  });
+
+  it('closes modal when close button is clicked', async () => {
+    await act(async () => {
+    render(<CalendarView />);
+    });
+    
+    fireEvent.click(screen.getByText('Mocked Calendar'));
+
+    // Find and click the first event in the calendar
+    const mockEvent = mockcalendarEvents[0];
+    const eventElement = screen.getByText(mockEvent.title);
+    fireEvent.click(eventElement);
+
+    // Ensure the modal is open
+    expect(screen.getByText(mockEvent.title)).toBeInTheDocument();
+
+    // Simulate clicking the close button
+    const closeButton = screen.getByText('Close');
+    fireEvent.click(closeButton);
+
+    // Ensure the modal is closed
+    await waitFor(() => {
+      expect(screen.queryByText(mockEvent.title)).not.toBeInTheDocument();
+    });
+    
+  });
+});
+

--- a/rebel-extension/src/tests/SidePanelButton.test.jsx
+++ b/rebel-extension/src/tests/SidePanelButton.test.jsx
@@ -21,7 +21,7 @@ describe("SidePanelButton", () => {
     render(<SidePanelButton />);
 
     expect(
-      screen.getByText(/Calendar View -->/i)
+      screen.getByText(/Calendar View/i)
     ).toBeInTheDocument();
   });
 


### PR DESCRIPTION
# Description
(Fixes #83 )
This feature adds additional functionality to the Calendar and the respective events it contains. Upon clicking an event, it will display a dialog window that contains relevant info saved within that event and is stylized for visual favorability.  The window will display the event's title, as well date, location, and additional description information. The window that opens also contains two (2) close buttons, one on the top right ( X - button ), and one on the bottom right ( [Close] - button ). Closing a window will allow the user to select another event to view afterward.

`react-bootstrap` was used in tandem with the `react-big-calendar` library, through bootstrap `Modal` component.

This also slightly changes the structure of the event storage system, where it now includes the addition of an "event id". Adding this one attribute to the events will allow for custom windows that will display information dynamically in the case of "events" versus "assignments":
"Event" Case: 
- `Started at: <Start Date and Time>`
- `Ends at: <End Date and Time>`
- `Location: <Sample Location>`
- `Description: <Additional Info>`
NOTE: If both 'start' and 'end' dates are the same, they will be replaced by `Date: <Overall Date and Time>`, AND 'Location' and 'Description' can be omitted. The window will simply not display the location or date if one or neither of them is not given.

"Assignment" Case:
- `Due: <Due Date and Time>`
- `Course: <Course Abbreviation + Number>`


Example Window (Event - "Maximum" and Event - "Minimal:):
![cal4](https://github.com/user-attachments/assets/aba0dd73-d778-4550-b8f3-3775fff16aef)
![cal3](https://github.com/user-attachments/assets/946b3cc8-5550-40cc-9318-6f0de6503b2b)


Example Window (Assignment):
![cal2](https://github.com/user-attachments/assets/c18d6e18-77f1-4a21-8919-14d63c7f6e2d)

# Miscellaneous
Smaller adjustments have been made to the appearance of the calendar, specifically how it first renders in a default (or freshly) opened browser. Due to Chrome API constraints, there is not programmatic way to force the sidepanel to open in a wider view. As such, I changed the positioning and scaling of the Calendar component, so that it will fit the window accordingly as the user drags the sidepanel.
(NOTE, this was recorded before I made positioning fix, so pardon the offset Calendar in this demonstration. The actual calendar in this PR has the proper positioning).

https://github.com/user-attachments/assets/4b226372-5110-4f62-8d7d-00d0b813f571



## Type of change
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
`Calendar.test.jsx`  ONLY tests the Calendar component, whereas
`Calendar2.test.jsx` ONLY tests the Modal component.

- [X] Manual Testing
- [X] Automated Unit Testing

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules

# UML Diagram
![CalendarModal drawio](https://github.com/user-attachments/assets/9921c855-4f18-4ced-afc8-d9aace1b9f41)
